### PR TITLE
feat: Revamp Interests section with new pages and game embed

### DIFF
--- a/activities/snow-sports.html
+++ b/activities/snow-sports.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Snow Sports - Activities - Geofratian.com</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+    <header>
+        <h1>About Me</h1>
+        <nav>
+            <ul>
+                <li><a href="../index.html">Home</a></li>
+                <li><a href="../about.html">About</a></li>
+                <li><a href="../research.html">Research</a></li>
+                <li><a href="../interests.html">Interests</a></li>
+                <li><a href="../contact.html">Contact Me</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="snow-sports-content">
+            <h1>Snow Sports</h1>
+            <p>Details about my experiences with Snow Sports coming soon.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Geo Fratian. All rights reserved.</p> </footer>
+
+</body>
+</html>

--- a/activities/soccer.html
+++ b/activities/soccer.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Soccer - Activities - Geofratian.com</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+    <header>
+        <h1>About Me</h1>
+        <nav>
+            <ul>
+                <li><a href="../index.html">Home</a></li>
+                <li><a href="../about.html">About</a></li>
+                <li><a href="../research.html">Research</a></li>
+                <li><a href="../interests.html">Interests</a></li>
+                <li><a href="../contact.html">Contact Me</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="soccer-content">
+            <h1>Soccer</h1>
+            <p>Details about my experiences with Soccer coming soon.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Geo Fratian. All rights reserved.</p> </footer>
+
+</body>
+</html>

--- a/activities/waterpolo.html
+++ b/activities/waterpolo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Water Polo - Activities - Geofratian.com</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+    <header>
+        <h1>About Me</h1>
+        <nav>
+            <ul>
+                <li><a href="../index.html">Home</a></li>
+                <li><a href="../about.html">About</a></li>
+                <li><a href="../research.html">Research</a></li>
+                <li><a href="../interests.html">Interests</a></li>
+                <li><a href="../contact.html">Contact Me</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="waterpolo-content">
+            <h1>Water Polo</h1>
+            <p>Details about my experiences with Water Polo coming soon.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Geo Fratian. All rights reserved.</p> </footer>
+
+</body>
+</html>

--- a/games.html
+++ b/games.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Games - Interests - Geofratian.com</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+    <header>
+        <h1>About Me</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="research.html">Research</a></li>
+                <li><a href="interests.html">Interests</a></li>
+                <li><a href="contact.html">Contact Me</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="games-content">
+            <h1>Games</h1>
+            <p>Content for Games coming soon.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Geo Fratian. All rights reserved.</p> </footer>
+
+</body>
+</html>

--- a/interests.html
+++ b/interests.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <header>
-        <h1>Research</h1>
+        <h1>Interests</h1>
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>
@@ -20,7 +20,44 @@
         </nav>
     </header>
     <main>
-        <p>This is where I'll write about myself.</p>
+        <h2>Interests</h2>
+
+        <section id="activities">
+            <h3>Activities</h3>
+            <ul>
+                <li><a href="activities/waterpolo.html">Water Polo</a></li>
+                <li><a href="activities/snow-sports.html">Snow Sports</a></li>
+                <li><a href="activities/soccer.html">Soccer</a></li>
+            </ul>
+        </section>
+
+        <section id="reading">
+            <h3>Reading</h3>
+            <ul>
+                <li><a href="reading/books.html">Books</a></li>
+                <li><a href="reading/comics.html">Comics</a></li>
+            </ul>
+        </section>
+
+        <section id="japanese">
+            <h3>Japanese</h3>
+            <p><a href="japanese.html">Learn more about my Japanese studies and projects.</a></p>
+        </section>
+
+        <section id="games">
+            <h3>Games</h3>
+            <p><a href="games.html">Check out games I enjoy or am working on.</a></p>
+        </section>
+
+        <section id="pictures">
+            <h3>Pictures</h3>
+            <p><a href="pictures.html">A gallery of interesting moments.</a></p>
+        </section>
+
+        <section id="physics">
+            <h3>Physics</h3>
+            <p><a href="physics.html">Exploring the laws of the universe.</a></p>
+        </section>
     </main>
     <footer>
         <p>&copy; 2025 Geo Fratian. All rights reserved.</p>

--- a/japanese.html
+++ b/japanese.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Japanese - Interests - Geofratian.com</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+    <header>
+        <h1>About Me</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="research.html">Research</a></li>
+                <li><a href="interests.html">Interests</a></li>
+                <li><a href="contact.html">Contact Me</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="japanese-content">
+            <h1>Japanese</h1>
+            <div class="game-container" style="text-align: center;">
+                <iframe
+                    src="https://derkt2.itch.io/final-project-japn0300"
+                    frameborder="0"
+                    width="990"
+                    height="600"
+                    allowfullscreen="">
+                    <a href="https://derkt2.itch.io/final-project-japn0300">Play Final Project JAPN0300 on itch.io</a>
+                </iframe>
+            </div>
+            <p>This was a game I had to make alongside classmates in my Japanese 0300 Class</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Geo Fratian. All rights reserved.</p> </footer>
+
+</body>
+</html>

--- a/physics.html
+++ b/physics.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Physics - Interests - Geofratian.com</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+    <header>
+        <h1>About Me</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="research.html">Research</a></li>
+                <li><a href="interests.html">Interests</a></li>
+                <li><a href="contact.html">Contact Me</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="physics-content">
+            <h1>Physics</h1>
+            <p>Content for Physics coming soon.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Geo Fratian. All rights reserved.</p> </footer>
+
+</body>
+</html>

--- a/pictures.html
+++ b/pictures.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pictures - Interests - Geofratian.com</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+    <header>
+        <h1>About Me</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="research.html">Research</a></li>
+                <li><a href="interests.html">Interests</a></li>
+                <li><a href="contact.html">Contact Me</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="pictures-content">
+            <h1>Pictures</h1>
+            <p>Content for Pictures coming soon.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Geo Fratian. All rights reserved.</p> </footer>
+
+</body>
+</html>

--- a/reading/books.html
+++ b/reading/books.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Books - Reading - Geofratian.com</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+    <header>
+        <h1>About Me</h1>
+        <nav>
+            <ul>
+                <li><a href="../index.html">Home</a></li>
+                <li><a href="../about.html">About</a></li>
+                <li><a href="../research.html">Research</a></li>
+                <li><a href="../interests.html">Interests</a></li>
+                <li><a href="../contact.html">Contact Me</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="books-content">
+            <h1>Books</h1>
+            <p>My favorite books and thoughts on reading coming soon.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Geo Fratian. All rights reserved.</p> </footer>
+
+</body>
+</html>

--- a/reading/comics.html
+++ b/reading/comics.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Comics - Reading - Geofratian.com</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+    <header>
+        <h1>About Me</h1>
+        <nav>
+            <ul>
+                <li><a href="../index.html">Home</a></li>
+                <li><a href="../about.html">About</a></li>
+                <li><a href="../research.html">Research</a></li>
+                <li><a href="../interests.html">Interests</a></li>
+                <li><a href="../contact.html">Contact Me</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section id="comics-content">
+            <h1>Comics</h1>
+            <p>My favorite comics and graphic novels coming soon.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Geo Fratian. All rights reserved.</p> </footer>
+
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a significant update to the "Interests" section:

- I updated `interests.html` to serve as a central hub with links to new dedicated pages for various interests.
- I created new top-level interest pages:
    - `japanese.html`: Includes an embedded playable version of a Ren'Py game from itch.io and a descriptive blurb.
    - `games.html` (placeholder content)
    - `pictures.html` (placeholder content)
    - `physics.html` (placeholder content)
- I created new sub-category pages under "Activities":
    - `activities/waterpolo.html` (placeholder)
    - `activities/snow-sports.html` (placeholder)
    - `activities/soccer.html` (placeholder)
- I created new sub-category pages under "Reading":
    - `reading/books.html` (placeholder)
    - `reading/comics.html` (placeholder)
- All new pages use a consistent site template with correct navigation paths and placeholder content where applicable.
- The main navigation bar remains unchanged; new pages are accessed via `interests.html`.