### PR TITLE
fix: Update game embed on Japanese page to use itch.io widget

### DIFF
--- a/japanese.html
+++ b/japanese.html
@@ -24,15 +24,8 @@
     <main>
         <section id="japanese-content">
             <h1>Japanese</h1>
-            <div class="game-container" style="text-align: center;">
-                <iframe
-                    src="https://derkt2.itch.io/final-project-japn0300"
-                    frameborder="0"
-                    width="990"
-                    height="600"
-                    allowfullscreen="">
-                    <a href="https://derkt2.itch.io/final-project-japn0300">Play Final Project JAPN0300 on itch.io</a>
-                </iframe>
+            <div class="game-widget-container" style="text-align: center; margin-bottom: 15px;">
+                <iframe frameborder="0" src="https://itch.io/embed/3109501" width="552" height="167"><a href="https://derkt2.itch.io/final-project-japn0300">Final Project JAPN0300 by derkt2</a></iframe>
             </div>
             <p>This was a game I had to make alongside classmates in my Japanese 0300 Class</p>
         </section>


### PR DESCRIPTION
I replaced the previous iframe embed for the Ren'Py game on `japanese.html` with the official itch.io widget embed code.

My previous attempt to directly embed the game's playable URL was blocked by itch.io's security policies. This change uses the widget code you provided: `<iframe frameborder="0" src="https://itch.io/embed/3109501" width="552" height="167">...</iframe>`

This will display an itch.io branded widget linking to the game, instead of a broken frame. The descriptive blurb below the game remains unchanged.