### PR TITLE
Add Languages section to Interests page

### DIFF
--- a/interests.html
+++ b/interests.html
@@ -39,9 +39,28 @@
             </ul>
         </section>
 
-        <section id="japanese">
-            <h3>Japanese</h3>
-            <p><a href="japanese.html">Learn more about my Japanese studies and projects.</a></p>
+        <section id="languages">
+            <h3>Languages</h3>
+            <section id="japanese">
+                <h4>Japanese</h4>
+                <p><a href="japanese.html">Learn more about my Japanese studies and projects.</a></p>
+                <p>Here are some fun facts about the Japanese language:</p>
+                <ul>
+                    <li>It has three distinct writing systems: Hiragana (for native Japanese words), Katakana (for foreign loanwords), and Kanji (adopted Chinese characters).</li>
+                    <li>Japanese uses a complex system of honorifics (keigo) to show respect, with different levels of politeness depending on the social status and relationship between speakers.</li>
+                    <li>Word order is quite different from English; the basic sentence structure is Subject-Object-Verb. For example, "I eat fish" would be "Watashi wa sakana o tabemasu" (I fish eat).</li>
+                </ul>
+            </section>
+
+            <section id="romanian">
+                <h4>Romanian</h4>
+                <p>Fun facts about the Romanian language:</p>
+                <ul>
+                    <li>It is a Romance language, closely related to Italian, Spanish, French, and Portuguese, yet it developed in relative isolation in Eastern Europe.</li>
+                    <li>Romanian is unique among Romance languages for attaching the definite article to the end of the noun (e.g., "om" means man, "omul" means the man).</li>
+                    <li>The Romanian alphabet includes special characters like "ă" (sounding like the 'a' in "sofa"), "î" and "â" (both representing a sound similar to the 'i' in "dirt" but more guttural), "ș" (sh), and "ț" (ts).</li>
+                </ul>
+            </section>
         </section>
 
         <section id="games">


### PR DESCRIPTION
This commit introduces a new "Languages" section to the interests.html page.

The changes include:
- A new top-level "Languages" section.
- Modification of the existing "Japanese" section to include fun facts about the language.
- Addition of a new "Romanian" section with fun facts about the language.
- Restructuring of headings to nest "Japanese" and "Romanian" under "Languages".